### PR TITLE
Added: Sorting and Alignment features to v2(a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "globset",
  "hex",
  "indicatif",
+ "lz4",
  "pulldown-cmark",
  "regex",
  "serde",
@@ -47,6 +48,7 @@ dependencies = [
  "tabled",
  "winres",
  "xxhash-rust",
+ "zstd",
 ]
 
 [[package]]
@@ -78,6 +80,15 @@ name = "bytecount"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
+name = "cc"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -235,6 +246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +267,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lz4"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9e2dd86df36ce760a60f6ff6ad526f7ba1f14ba0356f8254fb6905e6494df1"
+dependencies = [
+ "libc",
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -585,3 +625,32 @@ name = "xxhash-rust"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
+
+[[package]]
+name = "zstd"
+version = "0.12.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c947d2adc84ff9a59f2e3c03b81aa4128acf28d6ad7d56273f7e8af14e47bea"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cf39f730b440bab43da8fb5faf5f254574462f73f260f85f7987f32154ff17"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.4+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
+dependencies = [
+ "cc",
+ "libc",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.88"
 tabled = "0.10.0"
 xxhash-rust = { version = "0.8.5", features = ["xxh64"] }
+zstd = "0.12.1"
+lz4 = "1.23.1"
 
 [build-dependencies]
 pulldown-cmark = { version = "0.9.2", default-features = false }

--- a/src/archived_data.rs
+++ b/src/archived_data.rs
@@ -6,6 +6,20 @@ use flate2::bufread::ZlibDecoder;
 use flate2::Compression;
 use flate2::write::ZlibEncoder;
 
+pub fn zstd_extract(reader: &mut BufReader<File>, writer: &mut File, reader_offset: u32, compressed_size: u32) -> io::Result<usize> {
+    reader.seek(SeekFrom::Start(reader_offset as u64))?;
+    let compressed_data = reader.take(compressed_size as u64);
+    let mut decoder = zstd::Decoder::new(compressed_data)?;
+    Ok(io::copy(&mut decoder, writer)? as usize)
+}
+
+pub fn lz4_extract(reader: &mut BufReader<File>, writer: &mut File, reader_offset: u32, compressed_size: u32) -> io::Result<usize> {
+    reader.seek(SeekFrom::Start(reader_offset as u64))?;
+    let compressed_data = reader.take(compressed_size as u64);
+    let mut decoder = lz4::Decoder::new(compressed_data)?;
+    Ok(io::copy(&mut decoder, writer)? as usize)
+}
+
 pub fn zlib_extract(reader: &mut BufReader<File>, writer: &mut File, reader_offset: u32, compressed_size: u32) -> io::Result<usize> {
     reader.seek(SeekFrom::Start(reader_offset as u64))?;
     let compressed_data = reader.take(compressed_size as u64);

--- a/src/bfs.rs
+++ b/src/bfs.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use indicatif::ProgressBar;
 
-use crate::Format;
+use crate::{Compression, Format};
 use crate::util::FileHeaderTrait;
 use crate::v1::V1BfsFile;
 use crate::v2::V2BfsFile;
@@ -30,16 +30,16 @@ impl BfsFileTrait for BfsFile {
         })
     }
 
-    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool) -> io::Result<()> {
+    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool, compression: Compression) -> io::Result<()> {
         match format {
             Format::V1 | Format::V1a => {
-                V1BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate)
+                V1BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate, compression)
             }
             Format::V2 | Format::V2a => {
-                V2BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate)
+                V2BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate, compression)
             }
             Format::V3 => {
-                V3BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate)
+                V3BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate, compression)
             }
         }
     }
@@ -87,7 +87,7 @@ impl BfsFileTrait for BfsFile {
 
 pub trait BfsFileTrait: Sized {
     fn read_bfs_from_file(path: String, format: Format) -> io::Result<Self>;
-    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool) -> io::Result<()>;
+    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool, compression: Compression) -> io::Result<()>;
     fn get_file_count(&self) -> u32;
     fn get_data_offset(&self) -> u32;
     fn get_file_headers(&self) -> Vec<Box<dyn FileHeaderTrait>>;

--- a/src/bfs.rs
+++ b/src/bfs.rs
@@ -30,16 +30,16 @@ impl BfsFileTrait for BfsFile {
         })
     }
 
-    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool, compression: Compression) -> io::Result<()> {
+    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool, compression: Compression, align_front: bool, align_bytes: u32) -> io::Result<()> {
         match format {
             Format::V1 | Format::V1a => {
-                V1BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate, compression)
+                V1BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate, compression, align_front, align_bytes)
             }
             Format::V2 | Format::V2a => {
-                V2BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate, compression)
+                V2BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate, compression, align_front, align_bytes)
             }
             Format::V3 => {
-                V3BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate, compression)
+                V3BfsFile::archive(format, bfs_path, input_folder_path, input_files, verbose, filters, copy_filters, level, bar, file_version, deduplicate, compression, align_front, align_bytes)
             }
         }
     }
@@ -87,7 +87,7 @@ impl BfsFileTrait for BfsFile {
 
 pub trait BfsFileTrait: Sized {
     fn read_bfs_from_file(path: String, format: Format) -> io::Result<Self>;
-    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool, compression: Compression) -> io::Result<()>;
+    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool, compression: Compression, align_front: bool, align_bytes: u32) -> io::Result<()>;
     fn get_file_count(&self) -> u32;
     fn get_data_offset(&self) -> u32;
     fn get_file_headers(&self) -> Vec<Box<dyn FileHeaderTrait>>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,9 @@ enum Commands {
         bfs_name: String,
         /// Folder to archive
         input_folder: String,
+        /// Compression scheme. Non-zlib supported only for FO2 w/ Reloaded ModLoader add-in.
+        #[clap(long, value_enum, default_value_t = Compression::Zlib)]
+        compression: Compression,
         /// Compression level [0-9]
         #[clap(value_parser = clap::value_parser ! (u32).range(0..=9), short, long)]
         level: Option<u32>,
@@ -252,6 +255,13 @@ pub enum Format {
     V2,
     V2a,
     V3,
+}
+
+#[derive(ValueEnum, Clone, Eq, PartialEq, Copy)]
+pub enum Compression {
+    Zlib,
+    ZStd,
+    Lz4
 }
 
 #[derive(ValueEnum, Clone, Eq, PartialEq)]
@@ -615,7 +625,8 @@ fn main() {
             file_version: version,
             verbose,
             no_progress,
-            deduplicate
+            deduplicate,
+            compression,
         } => {
             let input_files = list_files_recursively(input_folder.clone());
 
@@ -641,7 +652,8 @@ fn main() {
                     level,
                     &bar,
                     version,
-                    deduplicate
+                    deduplicate,
+                    compression
                 ).expect("Failed to archive BFS file");
 
                 bar.finish_and_clear();

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,7 +260,7 @@ pub enum Format {
 #[derive(ValueEnum, Clone, Eq, PartialEq, Copy)]
 pub enum Compression {
     Zlib,
-    ZStd,
+    Zstd,
     Lz4
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ enum Commands {
         /// Compression scheme. Non-zlib supported only for FO2 w/ Reloaded ModLoader add-in.
         #[clap(long, value_enum, default_value_t = Compression::Zlib)]
         compression: Compression,
-        /// Compression level [0-9]
+        /// Compression level [0-9] for Zlib. [0-12] for LZ4, [0-22] for Zlib.
         #[clap(value_parser = clap::value_parser ! (u32).range(0..=9), short, long)]
         level: Option<u32>,
         /// Filter for compression - You can either supply the filter name or a filter file

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,13 @@ enum Commands {
         /// Stores all files with matching hash only once
         #[clap(long)]
         deduplicate: bool,
+        /// (v2/a only) If true aligns the data to the front for compatibility with non-PC platforms;
+        /// else allows some more customization for performance.
+        #[clap(default_value_t = true, long)]
+        align_front: bool,
+        /// (v2/a only) Aligns the data by a specified amount.
+        #[clap(long = "align", default_value_t = 4096)]
+        align_bytes: u32,
     },
     /// Identify an unknown BFS file using file hashes from bfs_file_dat.md
     #[clap(visible_alias = "i", visible_alias = "id", visible_alias = "info")]
@@ -638,6 +645,8 @@ fn main() {
             no_progress,
             deduplicate,
             compression,
+            align_front,
+            align_bytes
         } => {
             let input_files = list_files_recursively(input_folder.clone());
 
@@ -664,7 +673,9 @@ fn main() {
                     &bar,
                     version,
                     deduplicate,
-                    compression
+                    compression,
+                    align_front,
+                    align_bytes
                 ).expect("Failed to archive BFS file");
 
                 bar.finish_and_clear();

--- a/src/util.rs
+++ b/src/util.rs
@@ -205,6 +205,9 @@ pub fn align_file_in_stream_with_alignment(file_writer: &mut BufWriter<File>, fi
     
     // Get bytes remaining in slice
     let mut bytes_left_in_current_slice = align_number_to_next_multiple(pos as usize, alignment) - pos;
+    file_writer.seek(SeekFrom::Current(bytes_left_in_current_slice as i64))?;
+    return Ok(file_writer.stream_position()? as usize);
+    
     if bytes_left_in_current_slice == 0 {
         bytes_left_in_current_slice += alignment; // In case already aligned, for our fit check
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -186,19 +186,11 @@ pub fn get_sorted_indices<T: Ord>(data: &[T]) -> Vec<usize> {
     indices
 }
 
-/// Adds dummy padding to stream to align a file to default multiple 
-/// such that the end of the file will be aligned with specified alignment.
-///
-/// Files that fit within current alignment will not be aligned.
-pub fn align_file_in_stream(file_writer: &mut BufWriter<File>, file_size: usize) -> io::Result<usize> {
-    return align_file_in_stream_with_alignment(file_writer, file_size, 4096);
-}
-
 /// Adds dummy padding to stream to align a file to a specified multiple
 /// such that the end of the file will be aligned with specified alignment.
 /// 
 /// Files that fit within current alignment will not be aligned.
-pub fn align_file_in_stream_with_alignment(file_writer: &mut BufWriter<File>, file_size: usize, alignment: usize) -> io::Result<usize> {
+pub fn align_file_in_stream(file_writer: &mut BufWriter<File>, file_size: usize, alignment: usize, align_front: bool) -> io::Result<usize> {
     
     // Get space available in current alignment multiple.
     let pos = file_writer.stream_position()? as usize;
@@ -206,7 +198,10 @@ pub fn align_file_in_stream_with_alignment(file_writer: &mut BufWriter<File>, fi
     // Get bytes remaining in slice
     let mut bytes_left_in_current_slice = align_number_to_next_multiple(pos as usize, alignment) - pos;
     file_writer.seek(SeekFrom::Current(bytes_left_in_current_slice as i64))?;
-    return Ok(file_writer.stream_position()? as usize);
+    
+    if align_front { 
+        return Ok(file_writer.stream_position()? as usize); 
+    }
     
     if bytes_left_in_current_slice == 0 {
         bytes_left_in_current_slice += alignment; // In case already aligned, for our fit check

--- a/src/util.rs
+++ b/src/util.rs
@@ -162,3 +162,26 @@ pub fn write_data_to_file_endian(file_writer: &mut BufWriter<File>, data: Vec<u3
     }
     Ok(())
 }
+
+/// Gets all files from a hash map and orders them by name to hopefully group files loaded together
+pub fn get_all_files(lua_hash_files_map: &mut HashMap<u32, Vec<String>>) -> (Vec<&String>, Vec<usize>) {
+    let mut all_files = Vec::new();
+
+    for hash in 0..0x3E5 {
+        if let Some(files) = lua_hash_files_map.get(&hash) {
+            for file_path in files {
+                all_files.push(file_path);
+            }
+        }
+    }
+
+    let sorted_indices = get_sorted_indices(all_files.as_slice());
+    (all_files, sorted_indices)
+}
+
+/// Returns indices of vector in sorted order.
+pub fn get_sorted_indices<T: Ord>(data: &[T]) -> Vec<usize> {
+    let mut indices = (0..data.len()).collect::<Vec<_>>();
+    indices.sort_by_key(|&i| &data[i]);
+    indices
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use std::{fs, io};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::CString;
 use std::fs::File;
-use std::io::{BufWriter, Write};
+use std::io::{BufWriter, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use crate::Endianness;
@@ -184,4 +184,41 @@ pub fn get_sorted_indices<T: Ord>(data: &[T]) -> Vec<usize> {
     let mut indices = (0..data.len()).collect::<Vec<_>>();
     indices.sort_by_key(|&i| &data[i]);
     indices
+}
+
+/// Adds dummy padding to stream to align a file to default multiple 
+/// such that the end of the file will be aligned with specified alignment.
+///
+/// Files that fit within current alignment will not be aligned.
+pub fn align_file_in_stream(file_writer: &mut BufWriter<File>, file_size: usize) -> io::Result<usize> {
+    return align_file_in_stream_with_alignment(file_writer, file_size, 4096);
+}
+
+/// Adds dummy padding to stream to align a file to a specified multiple
+/// such that the end of the file will be aligned with specified alignment.
+/// 
+/// Files that fit within current alignment will not be aligned.
+pub fn align_file_in_stream_with_alignment(file_writer: &mut BufWriter<File>, file_size: usize, alignment: usize) -> io::Result<usize> {
+    
+    // Get space available in current alignment multiple.
+    let pos = file_writer.stream_position()? as usize;
+    
+    // Get bytes remaining in slice
+    let mut bytes_left_in_current_slice = align_number_to_next_multiple(pos as usize, alignment) - pos;
+    if bytes_left_in_current_slice == 0 {
+        bytes_left_in_current_slice += alignment; // In case already aligned, for our fit check
+    }
+        
+    if bytes_left_in_current_slice >= file_size {
+        return Ok(file_writer.stream_position()? as usize);
+    }
+    
+    let next_pos_rounded = align_number_to_next_multiple(pos + file_size, alignment);
+    let rounding_needed  = next_pos_rounded - (pos + file_size);
+    file_writer.seek(SeekFrom::Current(rounding_needed as i64))?;
+    return Ok(file_writer.stream_position()? as usize);
+}
+
+pub fn align_number_to_next_multiple(number: usize, alignment: usize) -> usize {
+    return ((number + alignment - 1) / alignment) * alignment;
 }

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -11,7 +11,7 @@ use xxhash_rust::xxh64::xxh64;
 
 pub use structs::*;
 
-use crate::{apply_copy_filters, Format};
+use crate::{apply_copy_filters, Compression, Format};
 use crate::archived_data::zlib_compress;
 use crate::bfs::BfsFileTrait;
 use crate::filter::apply_filters;
@@ -157,7 +157,7 @@ impl BfsFileTrait for V1BfsFile {
         Ok(result)
     }
 
-    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool) -> io::Result<()> {
+    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool, _compression: Compression) -> io::Result<()> {
         let mut bfs_file = V1BfsFile::default();
 
         bfs_file.bfs_header.magic = 0x31736662; // "bfs1"

--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -157,7 +157,7 @@ impl BfsFileTrait for V1BfsFile {
         Ok(result)
     }
 
-    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool, _compression: Compression) -> io::Result<()> {
+    fn archive(format: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], deduplicate: bool, _compression: Compression, _align_front: bool, _align_bytes: u32) -> io::Result<()> {
         let mut bfs_file = V1BfsFile::default();
 
         bfs_file.bfs_header.magic = 0x31736662; // "bfs1"

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -491,11 +491,11 @@ impl V2BfsFile {
             let compressed_data = match compression 
             {
                 Compression::Zlib => { zlib_compress(data, level)? },
-                Compression::ZStd => { zstd::stream::encode_all(data.as_slice(), 22)? },
+                Compression::ZStd => { zstd::stream::encode_all(data.as_slice(), level.unwrap() as i32)? },
                 Compression::Lz4 => {
                     let mut file : Vec<u8> = Vec::new();
                     let mut encode = EncoderBuilder::new()
-                        .level(12)
+                        .level(level.unwrap())
                         .favor_dec_speed(true)
                         .build(&mut file)?;
                     

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -344,76 +344,78 @@ impl BfsFileTrait for V2BfsFile {
         const JAMCRC: Crc<u32> = Crc::<u32>::new(&CRC_32_JAMCRC);
         let mut dedupe_hash_to_header = HashMap::<u64, FileHeader>::new();
 
-        for hash in 0..0x3E5 {
-            if let Some(files) = lua_hash_files_map.get(&hash) {
-                for file_path in files {
-                    let original_file_path = filenames.get(file_path).unwrap();
-                    let mut file = File::open(original_file_path)?;
-                    let mut data = Vec::new();
-                    file.read_to_end(&mut data)?;
-                    let (file_copies, file_copies_a) = copy_filters.get(file_path).unwrap().clone();
-                    let mut file_header = FileHeader {
-                        method: 0,
-                        file_copies,
-                        file_copies_a,
-                        data_offset: file_writer.stream_position()? as u32,
-                        unpacked_size: data.len() as u32,
-                        packed_size: 0,
-                        crc32: if format == Format::V2 {
-                            JAMCRC.checksum(&data)
-                        } else {
-                            0
-                        },
-                        folder_id: 0,
-                        file_id: 0,
-                        file_copies_offsets: vec![],
-                    };
-                    
-                    if let Some((folder, file)) = file_path.rsplit_once("/") {
-                        file_header.folder_id = name_ids.get(folder).unwrap().clone();
-                        file_header.file_id = name_ids.get(file).unwrap().clone();
-                    }
-                    
-                    let mut status= String::new();
+        let files = crate::util::get_all_files(&mut lua_hash_files_map);
+        bfs_file.file_headers.resize(files.0.len(), FileHeader::default());
+        
+        for i in 0..files.0.len() {
+            let file_index = files.1[i];
+            let file_path = files.0[file_index];
+            
+            let original_file_path = filenames.get(file_path).unwrap();
+            let mut file = File::open(original_file_path)?;
+            let mut data = Vec::new();
+            file.read_to_end(&mut data)?;
+            let (file_copies, file_copies_a) = copy_filters.get(file_path).unwrap().clone();
+            let mut file_header = FileHeader {
+                method: 0,
+                file_copies,
+                file_copies_a,
+                data_offset: file_writer.stream_position()? as u32,
+                unpacked_size: data.len() as u32,
+                packed_size: 0,
+                crc32: if format == Format::V2 {
+                    JAMCRC.checksum(&data)
+                } else {
+                    0
+                },
+                folder_id: 0,
+                file_id: 0,
+                file_copies_offsets: vec![],
+            };
 
-                    // Check duplicate
-                    if deduplicate {
-                        // Note: We hash separately using a hash with longer value as I (Sewer) don't like
-                        // probability of collision with 32-bit hash.
-                        let dedupe_hash: u64 = xxh64(&data, 0);
-                        
-                        // Note: We have to account for the case where one file is compressed but another file isn't, so make
-                        // sure the compress state matches existing file.
-                        let should_compress_file = Self::should_compress_file(level, &files_to_compress, file_path);
-                        
-                        if let Some(cached_header) = dedupe_hash_to_header.get(&dedupe_hash) {
-                            if should_compress_file == cached_header.is_compressed() && cached_header.unpacked_size == file_header.unpacked_size {
-                                file_header.method = cached_header.method;
-                                file_header.packed_size = cached_header.packed_size;
-                                file_header.data_offset = cached_header.data_offset;
-                                status = format!("{} bytes, deduplicated", file_header.packed_size);
-                            }
-                            else {
-                                Self::write_file_to_output(&format, level, &mut file_writer, &mut files_to_compress, file_path, data, &mut file_header, &mut status, compression)?;
-                            }
-                        }
-                        else {
-                            Self::write_file_to_output(&format, level, &mut file_writer, &mut files_to_compress, file_path, data, &mut file_header, &mut status, compression)?;
-                            dedupe_hash_to_header.insert(dedupe_hash, file_header.clone());
-                        }
+            if let Some((folder, file)) = file_path.rsplit_once("/") {
+                file_header.folder_id = name_ids.get(folder).unwrap().clone();
+                file_header.file_id = name_ids.get(file).unwrap().clone();
+            }
+
+            let mut status= String::new();
+
+            // Check duplicate
+            if deduplicate {
+                // Note: We hash separately using a hash with longer value as I (Sewer) don't like
+                // probability of collision with 32-bit hash.
+                let dedupe_hash: u64 = xxh64(&data, 0);
+
+                // Note: We have to account for the case where one file is compressed but another file isn't, so make
+                // sure the compress state matches existing file.
+                let should_compress_file = Self::should_compress_file(level, &files_to_compress, file_path);
+
+                if let Some(cached_header) = dedupe_hash_to_header.get(&dedupe_hash) {
+                    if should_compress_file == cached_header.is_compressed() && cached_header.unpacked_size == file_header.unpacked_size {
+                        file_header.method = cached_header.method;
+                        file_header.packed_size = cached_header.packed_size;
+                        file_header.data_offset = cached_header.data_offset;
+                        status = format!("{} bytes, deduplicated", file_header.packed_size);
                     }
                     else {
                         Self::write_file_to_output(&format, level, &mut file_writer, &mut files_to_compress, file_path, data, &mut file_header, &mut status, compression)?;
                     }
-                    
-                    if verbose {
-                        bar.println(format!("{file_path:?} {status}"));
-                    }
-                    bar.inc(1);
-
-                    bfs_file.file_headers.push(file_header);
+                }
+                else {
+                    Self::write_file_to_output(&format, level, &mut file_writer, &mut files_to_compress, file_path, data, &mut file_header, &mut status, compression)?;
+                    dedupe_hash_to_header.insert(dedupe_hash, file_header.clone());
                 }
             }
+            else {
+                Self::write_file_to_output(&format, level, &mut file_writer, &mut files_to_compress, file_path, data, &mut file_header, &mut status, compression)?;
+            }
+
+            if verbose {
+                bar.println(format!("{file_path:?} {status}"));
+            }
+            bar.inc(1);
+
+            bfs_file.file_headers[file_index] = file_header;
         }
 
         if verbose {

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -478,7 +478,7 @@ impl V2BfsFile {
             let compression_flag = match compression 
             {
                 Compression::Zlib => { 1 } // base compression flag
-                Compression::ZStd => { 0b1000 | 1 }
+                Compression::Zstd => { 0b1000 | 1 }
                 Compression::Lz4 => { 0b10000 | 1 }
             };
             
@@ -491,7 +491,7 @@ impl V2BfsFile {
             let compressed_data = match compression 
             {
                 Compression::Zlib => { zlib_compress(data, level)? },
-                Compression::ZStd => { zstd::stream::encode_all(data.as_slice(), level.unwrap() as i32)? },
+                Compression::Zstd => { zstd::stream::encode_all(data.as_slice(), level.unwrap() as i32)? },
                 Compression::Lz4 => {
                     let mut file : Vec<u8> = Vec::new();
                     let mut encode = EncoderBuilder::new()

--- a/src/v3/mod.rs
+++ b/src/v3/mod.rs
@@ -187,7 +187,7 @@ impl BfsFileTrait for V3BfsFile {
         Ok(result)
     }
 
-    fn archive(_: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], _deduplicate: bool, _compression: Compression) -> io::Result<()> {
+    fn archive(_: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], _deduplicate: bool, _compression: Compression, _align_front: bool, _align_bytes: u32) -> io::Result<()> {
         let mut bfs_file = Self::default();
 
         bfs_file.bfs_header.magic = 0x31736662; // "bfs1"

--- a/src/v3/mod.rs
+++ b/src/v3/mod.rs
@@ -9,7 +9,7 @@ use indicatif::ProgressBar;
 
 pub use structs::*;
 
-use crate::{apply_copy_filters, Format};
+use crate::{apply_copy_filters, Compression, Format};
 use crate::archived_data::zlib_compress;
 use crate::bfs::BfsFileTrait;
 use crate::filter::apply_filters;
@@ -187,7 +187,7 @@ impl BfsFileTrait for V3BfsFile {
         Ok(result)
     }
 
-    fn archive(_: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], _deduplicate: bool) -> io::Result<()> {
+    fn archive(_: Format, bfs_path: String, input_folder_path: String, input_files: Vec<String>, verbose: bool, filters: Vec<String>, copy_filters: Vec<String>, level: Option<u32>, bar: &ProgressBar, file_version: [u8; 4], _deduplicate: bool, _compression: Compression) -> io::Result<()> {
         let mut bfs_file = Self::default();
 
         bfs_file.bfs_header.magic = 0x31736662; // "bfs1"


### PR DESCRIPTION
# About
This pull request adds the following features to packing v2(a) BFS archives:

- Sorting files by name to reduce seek times.  
- Allowing files to be aligned to specified alignment boundaries.  
- Default alignment mode aligns the file to the start of the specified boundary, which should fix packing for some games like the XBOX version/prototype of FlatOut 2.  
- LZ4 and ZStandard compression support [requires a specific mod](https://sewer56.dev/FlatOut2.Utils.ModLoader/). These are implemented as 0x8 and 0x10 flags and don't conflict with any flags from other tools/base game.
- An optional feature to relax alignment rules with `align_front == false` to create BFSes optimal for the PC platform where files don't have to be aligned to load.  


These features were only added to v2(a) because I do not have the means to test other versions. 
Please review the changes and merge them into the main branch if everything looks good. Thank you!

🐱